### PR TITLE
add date and schedule link

### DIFF
--- a/2024/README.md
+++ b/2024/README.md
@@ -112,7 +112,7 @@ All paper submissions that receive favorable reviews will be included as part of
 14 Aug 2024        | Paper submission deadline (second extension)
 06 Sep 2024        | Author notification
 27 Sep 2024        | Camera ready copy due (note: this deadline is FIRM)
-Nov 2024           | ISAV'24 workshop at SC24
+17 Nov 2024        | [ISAV'24 workshop at SC24](https://sc24.conference-program.com/presentation/?id=wksp140&sess=sess360)
 
 
 ## Committees and Chairs


### PR DESCRIPTION
The schedule is up for SC, which lists ISAV on Nov 17 at 2pm: https://sc24.conference-program.com/presentation/?id=wksp140&sess=sess360 , I added the date + a link to the schedule